### PR TITLE
Create AbstractExpressiveContainerConfigTest with required test traits composed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 0.1.0 - TBD
+## 0.1.0 - 2018-04-10
+
+Initial public release.
 
 ### Added
 
-- Nothing.
+- Everything.
 
 ### Changed
 

--- a/src/AbstractContainerTest.php
+++ b/src/AbstractContainerTest.php
@@ -12,7 +12,7 @@ namespace Zend\ContainerConfigTest;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-abstract class ContainerTest extends TestCase
+abstract class AbstractContainerTest extends TestCase
 {
     abstract protected function createContainer(array $config) : ContainerInterface;
 }

--- a/src/AbstractExpressiveContainerConfigTest.php
+++ b/src/AbstractExpressiveContainerConfigTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-container-config-test for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-container-config-test/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\ContainerConfigTest;
+
+/**
+ * Extend this class and implement createContainer in order to verify that
+ * your container implementation will work as expected when provided with
+ * Expressive DI container configuration.
+ */
+abstract class AbstractExpressiveContainerConfigTest extends AbstractContainerTest
+{
+    use AliasTestTrait;
+    use DelegatorTestTrait;
+    use FactoryTestTrait;
+    use InvokableTestTrait;
+    use ServiceTestTrait;
+}

--- a/src/AllTestTrait.php
+++ b/src/AllTestTrait.php
@@ -11,9 +11,6 @@ namespace Zend\ContainerConfigTest;
 
 trait AllTestTrait
 {
-    use AliasTestTrait;
-    use DelegatorTestTrait;
-    use FactoryTestTrait;
-    use InvokableTestTrait;
-    use ServiceTestTrait;
+    use ExpressiveTestTrait;
+    use SharedTestTrait;
 }

--- a/src/ExpressiveTestTrait.php
+++ b/src/ExpressiveTestTrait.php
@@ -7,12 +7,13 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\ContainerConfigTest;
+namespace Zend\ContainerConfigTest;
 
-use Zend\ContainerConfigTest\AllTestTrait;
-use Zend\ContainerConfigTest\ContainerTest;
-
-abstract class BaseContainerTest extends ContainerTest
+trait ExpressiveTestTrait
 {
-    use AllTestTrait;
+    use AliasTestTrait;
+    use DelegatorTestTrait;
+    use FactoryTestTrait;
+    use InvokableTestTrait;
+    use ServiceTestTrait;
 }

--- a/test/AuraDiTest.php
+++ b/test/AuraDiTest.php
@@ -12,8 +12,9 @@ namespace ZendTest\ContainerConfigTest;
 use Psr\Container\ContainerInterface;
 use Zend\AuraDi\Config\Config;
 use Zend\AuraDi\Config\ContainerFactory;
+use Zend\ContainerConfigTest\AbstractExpressiveContainerConfigTest;
 
-class AuraDiTest extends BaseContainerTest
+class AuraDiTest extends AbstractExpressiveContainerConfigTest
 {
     public function createContainer(array $config) : ContainerInterface
     {

--- a/test/PimpleTest.php
+++ b/test/PimpleTest.php
@@ -10,10 +10,11 @@ declare(strict_types=1);
 namespace ZendTest\ContainerConfigTest;
 
 use Psr\Container\ContainerInterface;
+use Zend\ContainerConfigTest\AbstractExpressiveContainerConfigTest;
 use Zend\Pimple\Config\Config;
 use Zend\Pimple\Config\ContainerFactory;
 
-class PimpleTest extends BaseContainerTest
+class PimpleTest extends AbstractExpressiveContainerConfigTest
 {
     public function createContainer(array $config) : ContainerInterface
     {

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -10,10 +10,11 @@ declare(strict_types=1);
 namespace ZendTest\ContainerConfigTest;
 
 use Psr\Container\ContainerInterface;
+use Zend\ContainerConfigTest\AbstractExpressiveContainerConfigTest;
 use Zend\ContainerConfigTest\SharedTestTrait;
 use Zend\ServiceManager\ServiceManager;
 
-class ServiceManagerTest extends BaseContainerTest
+class ServiceManagerTest extends AbstractExpressiveContainerConfigTest
 {
     use SharedTestTrait;
 


### PR DESCRIPTION
This patch builds on [a comment on #2](https://github.com/zendframework/zend-container-config-test/pull/2#issuecomment-378847288).

First, it renames `ContainerTest` to `AbstractContainerTest`, in order to follow our naming guidelines for abstract classes.

Second, it introduces `ExpressiveTestTrait`, which composes the various traits that are _required_ by implementations in order to be compatible with Expressive configuration.

Third, it modifies `AllTestTrait` to use `ExpressiveTestTrait` as well as `SharedTestTrait`.

Fourth, it introduces `AbstractExpressiveContainerConfigTest`, which extends `AbstractContainerTest` and composes `ExpressiveTestTrait`.

Fifth, it removes the `BaseContainerTest` as redundant to the new `AbstractExpressiveContainerConfigTest`, and updates all test classes to extend it.