### PR TITLE
Fix README.md - use `SharedTestTrait` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ the `SharedTestTrait` as well:
 
 ```php
 use Zend\ContainerConfigTest\AbstractExpressiveContainerConfigTest;
-use Zend\ContainerConfigTest\ServiceTestTrait;
+use Zend\ContainerConfigTest\SharedTestTrait;
 
 class ContainerTest extends AbstractExpressiveContainerConfigTest
 {
-    use ServiceTestTrait;
+    use SharedTestTrait;
     
     protected function createContainer(array $config) : ContainerInterface
     {


### PR DESCRIPTION
- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
